### PR TITLE
Fix readme applyMiddleware example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ const config = {
 
 const debouncer = createDebounce(config)
 const logger = createLogger()
-const createMiddleware = applyMiddleware(thunk, debouncer, promise, thunk)
+const createMiddleware = applyMiddleware(thunk, debouncer, promise, logger)
 const store = createMiddleware(createStore)(reducer)
 
 const debounceAction = () => ({


### PR DESCRIPTION
The README example was previously importing thunk twice and logger never.